### PR TITLE
Fix Quote Tweet display bugs

### DIFF
--- a/TwitterKit/TwitterKit/Social/Syndication/Views/TWTRTweetView.m
+++ b/TwitterKit/TwitterKit/Social/Syndication/Views/TWTRTweetView.m
@@ -340,9 +340,15 @@ static TWTRTweetViewTheme const TWTRTweetViewDefaultTheme = TWTRTweetViewThemeLi
     self.layer.cornerRadius = self.showBorder ? TWTRTweetViewCornerRadius : 0.0;
     self.clipsToBounds = YES;
 
+  if (self.tweet.isQuoteTweet) {
     self.attachmentContainer.layer.borderColor = borderColor.CGColor;
     self.attachmentContainer.layer.borderWidth = (2 * TWTRTweetViewBorderWidth);
     self.attachmentContainer.layer.cornerRadius = TWTRTweetViewCornerRadius;
+  } else {
+    self.attachmentContainer.layer.borderColor = UIColor.clearColor.CGColor;
+    self.attachmentContainer.layer.borderWidth = 0;
+    self.attachmentContainer.layer.cornerRadius = 0;
+  }
 }
 
 - (void)setShowActionButtons:(BOOL)showActionButtons

--- a/TwitterKit/TwitterKit/Social/Syndication/Views/TWTRTweetView.m
+++ b/TwitterKit/TwitterKit/Social/Syndication/Views/TWTRTweetView.m
@@ -453,9 +453,8 @@ static TWTRTweetViewTheme const TWTRTweetViewDefaultTheme = TWTRTweetViewThemeLi
         [subview removeFromSuperview];
     }
 
-    // Currently only show a quote tweet as an attachment
-    // If content view already has media, does not show a quote tweet attachment
-    if (tweet.isQuoteTweet && !tweet.hasMedia) {
+    // FIX(@benward): Twitter now allows Quote Tweets and photos together
+    if (tweet.isQuoteTweet) {
         id<TWTRTweetContentViewLayout> layout = [TWTRTweetContentViewLayoutFactory quoteTweetViewLayoutWithMetrics:self.metrics];
         TWTRTweetContentView *contentView = [[TWTRTweetContentView alloc] initWithLayout:layout];
         [self.attachmentContainer addSubview:contentView];


### PR DESCRIPTION
Problem

1. Twitter have updated their display guidelines to allow displaying Tweet media and Quote tweets at the same time.
2. Twitter Kit has a bug where the border outline for the Quote Tweet can still be hairline visible when there is no Quote Tweet.

Solution

* Remove restriction on rendering Quote when media is present.
* Explicitly render clear borders on attachment region when Quote is missing.

Result

* No visual glitch
* Quotes and media can be rendered together.

Not addressed

* Delegate handling for media handling assumes a single Tweet. There might be more work to do to enable interaction with quoted video + a reaction GIF, for example.
